### PR TITLE
Adding edmfields.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 						
 
 
-add_executable(PENTrack main.cpp globals.cpp trianglemesh.cpp geometry.cpp mc.cpp bruteforce.cpp 
+add_executable(PENTrack main.cpp globals.cpp trianglemesh.cpp geometry.cpp mc.cpp bruteforce.cpp edmfields.cpp 
 						field_2d.cpp field_3d.cpp fields.cpp conductor.cpp particle.cpp neutron.cpp 
 						electron.cpp proton.cpp mercury.cpp xenon.cpp ndist.cpp source.cpp 
 						$<TARGET_OBJECTS:alglib> $<TARGET_OBJECTS:muparser> $<TARGET_OBJECTS:libtricubic>)		

--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ If bruteforce integration of particle spin precession is active, it will be logg
 - Ix, Iy, Iz: x, y and z components of the Bloch vector (times 2) [dimensionless]
 - Bx, By, Bz: x, y and z components of magnetic field direction vector (B[i]/Babs) [dimensionless]
 
+### Writing Output files to ROOT readable files
+
+merge_all.c: A [ROOT](http://root.cern.ch) script that writes all out-files (or those, whose filename matches some pattern) into a single ROOT file containing trees for each log- and particle-type.
+
+Helper Scripts 
+--------------
+
 ### preRunCheck.sh
 
 This script performs some preliminary checks before launching a large batch PENTrack job. The checks performed are:
@@ -212,20 +219,20 @@ This script performs some preliminary checks before launching a large batch PENT
 
 The script also generates a batch.pbs that can be submitted to a TORQUE queueing system. The batch script can be customized by entering the following command line input in this order: 
 
-- minJobNum - the lower bound of the job array id specified in the batch file (default is 1) 
-- maxJobNum - the upper bound of the job array id specified in the batch file (default is 10, so if minJobNum=1 and maxJobNum=10, submitting the batch file would result in 10 PENTrack jobs being run the job numbers ranging from 1-10)
-- jobName - the name of the job that will displayed when you check the status of the jobs using the `qstat` command (default is SampleRun)
-- inDirName - the relative path to the directory containing PENTrack's input files (the geometry.in file in this directory will be checked, default is in/)
-- outDirName - the relative path to the directory where the job output will be written (the cases for overwriting previous jobs will be checked in this directory, default is out/)
-- pbsfileName - the name of the batch file being generated (default name is batch.pbs)
-- wallTime - the walltime requested from the queueing system, it must be entered in the following format: 1d4h30m which means the time requested is: 1 day + 4 hours + 30 minutes (you can only specify days or hours or minutes but they order must remain: day, hours, minutes). You can also specify 120m and the batch file will correctly set the time to 2 hours. A warning will be given 
+1. minJobNum - the lower bound of the job array id specified in the batch file (default is 1) 
+2. maxJobNum - the upper bound of the job array id specified in the batch file (default is 10, so if minJobNum=1 and maxJobNum=10, submitting the batch file would result in 10 PENTrack jobs being run the job numbers ranging from 1-10)
+3. jobName - the name of the job that will displayed when you check the status of the jobs using the `qstat` command (default is SampleRun)
+4. inDirName - the relative path to the directory containing PENTrack's input files (the geometry.in file in this directory will be checked, default is in/)
+5. outDirName - the relative path to the directory where the job output will be written (the cases for overwriting previous jobs will be checked in this directory, default is out/)
+6. pbsfileName - the name of the batch file being generated (default name is batch.pbs)
+7. wallTime - the walltime requested from the queueing system, it must be entered in the following format: 1d4h30m which means the time requested is: 1 day + 4 hours + 30 minutes (you can only specify days or hours or minutes but they order must remain: day, hours, minutes). You can also specify 120m and the batch file will correctly set the time to 2 hours. A warning will be given 
 
 ### postRunCheck.sh
 
 This script performs some basic error checks after a batch run of PENTrack has finished execution. The two required inputs are: 
 
-- expectedNumJobs - the number of jobs that were part of the batch run which is to be checked
-- outDirName - the relative path to the output directory where the output from the batch run was written 
+1. expectedNumJobs - the number of jobs that were part of the batch run which is to be checked
+2. outDirName - the relative path to the output directory where the output from the batch run was written 
 
 The checks performed by the script are: 
 
@@ -252,7 +259,4 @@ The output from the script is directed to standard out is meant to be copied int
 1. stlDirName - the relative path to the directory containing the STL files that are to be processed
 2. specialPathToSTL - specify this if you wish to append a prefix to the relative path of the STL files. This is useful if you are running the script in a location that has a different relative path to the STL directory in comparison to the location of the PENTrack executable. 
 
-### Writing Output files to ROOT readable files
-
-merge_all.c: A [ROOT](http://root.cern.ch) script that writes all out-files (or those, whose filename matches some pattern) into a single ROOT file containing trees for each log- and particle-type.
 

--- a/bruteforce.cpp
+++ b/bruteforce.cpp
@@ -45,7 +45,7 @@ void TBFIntegrator::operator()(const state_type &y, value_type x){
 			exit(-1);
 		}
 		fspinout.precision(10);
-		fspinout << "t Babs Polar logPolar Ix Iy Iz Bx/Babs By/Babs Bz/Babs\n";
+		fspinout << "t Babs Polar logPolar Ix Iy Iz Bx By Bz\n";
 	}
 
 	value_type B[3];

--- a/bruteforce.cpp
+++ b/bruteforce.cpp
@@ -45,7 +45,7 @@ void TBFIntegrator::operator()(const state_type &y, value_type x){
 			exit(-1);
 		}
 		fspinout.precision(10);
-		fspinout << "t Babs Polar logPolar Ix Iy Iz Bx By Bz\n";
+		fspinout << "t Babs Polar logPolar Ix Iy Iz Bx/Babs By/Babs Bz/Babs\n";
 	}
 
 	value_type B[3];

--- a/edmfields.cpp
+++ b/edmfields.cpp
@@ -1,0 +1,46 @@
+
+/**
+ * \file
+ * The EDM fields used in the Ramsey Cycle
+*/
+
+#include <cmath>
+#include "edmfields.h"
+
+TEDMStaticB0GradZField::TEDMStaticB0GradZField(double abz, double adB0zdz): edmB0z0(abz), edmdB0z0dz(adB0zdz) {}; //end constructor
+
+void TEDMStaticB0GradZField::BField(double x, double y, double z, double t, double B[4][4]){
+	
+	//Calculations for the first row of the matrix i.e. all the x parts
+	B[0][0] += -x/2*edmdB0z0dz; // Bx
+	B[0][1] += -edmdB0z0dz/2; //dBxdx
+	B[0][2] += 0; B[0][3] += 0; //dBxdy, dBxdz
+
+    	//Calculations for the second row of the matrix i.e. all the y parts
+    	B[1][0] += -y/2*edmdB0z0dz; // By
+    	B[1][1] += 0; B[1][3] += 0; //dBydx, dBy/dz
+    	B[1][2] += -edmdB0z0dz/2; //dBydy
+
+    	//Calculations for the third row of the matrix i.e. all the z parts
+   	B[2][0] += edmB0z0 + edmdB0z0dz*z; // Bz
+   	B[2][1] += 0; B[2][2] += 0; //dBzdx, dBzdy
+    	B[2][3] += edmdB0z0dz; //dBzdz
+
+    	//Calculations for the fourth row of the matrix i.e. all |B| parts
+    	B[3][0] += sqrt((x*x + y*y + 4*z*z)*edmdB0z0dz*edmdB0z0dz/4 + 2*edmB0z0*edmdB0z0dz*z + edmB0z0*edmB0z0); //(should give the same results as calculation below)
+//    	B[3][0] += sqrt(pow(B[0][0], 2) + pow(B[1][0], 2) + pow(B[2][0], 2)); // |B| (not correct when there will be other fields)
+    	B[3][1] += (x*pow(edmdB0z0dz,2))/sqrt((x*x + y*y + 4*z*z)*edmdB0z0dz*edmdB0z0dz/4 + 2*edmB0z0*edmdB0z0dz*z + edmB0z0*edmB0z0); // d|B|/dx
+    	B[3][2] += (y*pow(edmdB0z0dz,2))/sqrt((x*x + y*y + 4*z*z)*edmdB0z0dz*edmdB0z0dz/4 + 2*edmB0z0*edmdB0z0dz*z + edmB0z0*edmB0z0); //d|B|/dy
+    	B[3][3] += (pow(edmdB0z0dz, 2)*z + edmB0z0*edmdB0z0dz)/sqrt((x*x + y*y + 4*z*z)*edmdB0z0dz*edmdB0z0dz/4 + 2*edmB0z0*edmdB0z0dz*z + edmB0z0*edmB0z0); //d|B|/dz
+
+} // end TEDMStaticB0GradZField::BField
+
+TEDMStaticEField::TEDMStaticEField (double amagEField): magEField(amagEField) {}; //end TEDMStaticEField constructor
+
+void TEDMStaticEField::EField (double x, double y, double z, double t, double &V, double Ei[3]) {
+	Ei[0] += 0; Ei[1] += 0;
+	Ei[2] += magEField;
+
+	//V = integrate(E*r) => V = E_z * z
+	V += Ei[2]*z;
+} //end TEDMStaticEField::EField 

--- a/edmfields.h
+++ b/edmfields.h
@@ -1,0 +1,88 @@
+/**
+ * \file
+ * The EDM fields used in the Ramsey cycle. 
+ */
+
+#ifndef STATICEDMFIELD_H_
+#define STATICEDMFIELD_H_
+
+#include "field.h"
+
+/**
+ * Magnetic field definition for the static B_0 field experienced by neutrons throughout the Ramsey cycle.
+ */
+
+struct TEDMStaticB0GradZField: public TField{
+	double edmB0z0; ///< z component of B0 field at the origin in T
+	double edmdB0z0dz; ///< z derivative of z component of the B0 field: dB0zdz at the origin in T
+
+	/**
+	 * Constructor, requires B0z component at centre of the EDM cell and the derivative of the B0z component along the z-axis.
+	 */
+	TEDMStaticB0GradZField(double abz, double adB0zdz);
+	
+	/**
+	 * The calculation for the B0 components are derived from a first order approximation of
+	 * an axially symmetric static magnetic field. See for example: http://physics.princeton.edu/~mcdonald/examples/axial.pdf
+	 *
+	 * @param x, the x-coordinate in the field's coordinate system
+	 * @param y, the x-coordinate in the field's coordinate system
+	 * @param z, the x-coordinate in the field's coordinate system
+	 * @param t, the time (not used since the field is presumed to be static)
+	 * @param B, Magnetic field component matrix to which the values are added
+	**/
+	void BField(double x, double y, double z, double t, double B[4][4]);
+	
+	/**
+	 * Adds no electric field. 
+	 * Required because we are inheriting from abstract class TField which has virtual void EField function.
+	 *
+	 * @param x Cartesian x coordinate
+	 * @param y Cartesian y coordinate
+	 * @param z Cartesian z coordinate
+	 * @param t Time
+	 * @param V Electric potential
+	 * @param Ei Electric field components
+	 */
+	void EField(double x, double y, double z, double t, double &V, double Ei[3]) {};
+};
+
+/**
+ * The static homogenous field that is parallel to the B0 field.
+ * 
+ */
+struct TEDMStaticEField: public TField {
+	double magEField; 	
+
+	/**
+ 	* Constructor requires just the magnitude of the field. 
+ 	*/
+	TEDMStaticEField(double amagEField);
+
+	/**
+	 * Adds no magnetic field.
+	 *
+	 * @param x, the x-coordinate in the field's coordinate system
+	 * @param y, the x-coordinate in the field's coordinate system
+	 * @param z, the x-coordinate in the field's coordinate system
+	 * @param t, the time (not used since the field is presumed to be static)
+	 * @param B, Magnetic field component matrix to which the values are added
+	**/
+	void BField(double x, double y, double z, double t, double B[4][4]) {};
+	
+	/**
+	 * The static E field should be parallel to the B0 field in Ramsey cycle.
+	 *
+	 * @param x Cartesian x coordinate
+	 * @param y Cartesian y coordinate
+	 * @param z Cartesian z coordinate
+	 * @param t Time
+	 * @param V Electric potential
+	 * @param Ei Electric field components
+	 */
+	void EField(double x, double y, double z, double t, double &V, double Ei[3]); 
+
+};
+
+
+#endif /*STATICEDMFIELD_H_*/

--- a/fields.cpp
+++ b/fields.cpp
@@ -14,6 +14,7 @@
 #include "field_2d.h"
 #include "field_3d.h"
 #include "conductor.h"
+#include "edmfields.h"
 
 using namespace std;
 
@@ -77,6 +78,16 @@ TFieldManager::TFieldManager(TConfig &conf, int aFieldOscillation, double aOscil
 			ss >> Ibar >> p1 >> p2 >> p3;
 			if (ss)
 				f = new TFullRacetrack(p1, p2, p3, Ibar);
+		} 
+		else if (i->first == "EDMStaticB0GradZField") {
+			ss >> p1 >> p2; 
+			if (ss) 
+				f = new TEDMStaticB0GradZField(p1, p2);
+		}
+		else if (i->first == "EDMStaticEField") {
+			ss >> p1;
+			if (ss)
+				f = new TEDMStaticEField (p1);
 		}
 
 		if (f)

--- a/preRunCheck.sh
+++ b/preRunCheck.sh
@@ -249,10 +249,11 @@ if [ "$files" != 0 ]; then
 	errorNums=`ls $outDirName/error.txt* | sed 's/error.txt-//g' | sed "s|$outDirName/||g"`
 fi
 
-files=$(ls $outDirName/*.out | grep -v "BFCut" 2> /dev/null | wc -l)
+files=$(ls $outDirName/*.out | grep -v "BFCut\|MR" 2> /dev/null | wc -l)
 
 if [  "$files" != 0 ]; then 
-	outLogNums=`ls $outDirName/*.out | sed "s|$outDirName/||g" | sed 's/^0*//g' | sed 's/.out//g' | sed 's/proton//g' | sed 's/neutron//g' | sed 's/electron//g' | sed 's/out\///g' \
+	outLogNums=`ls $outDirName/*.out | sed "s|$outDirName/||g" | sed 's/^0*//g' | sed 's/.out//g' | sed 's/proton//g' \
+		| sed 's/neutron//g' | sed 's/electron//g' | sed 's/xenon//g' | sed 's/mercury//g' | sed 's/out\///g' \
 		| sed 's/end//g' | sed 's/snapshot//g' | sed 's/hit//g' | sed 's/track//g' | sed 's/spin//g'`
 fi 
 


### PR DESCRIPTION
edmfields.cpp is a new class that will hold all the E&B field definitions to be used for an EDM measurement simulation. 

Also reverted back to the old header in the spinlog because the out.root file produced with the new header doesn't work when there is "/" sign. But maybe you should not be dividing Bx, By, Bz by Babs in the spinlog out (see the issue I added). 