### PR TITLE
Added vxE to BFintegrator and option to do simultaneous integration of particle spin with anti-parallel E-field

### DIFF
--- a/bruteforce.cpp
+++ b/bruteforce.cpp
@@ -14,6 +14,7 @@ TBFIntegrator::TBFIntegrator(double agamma, std::string aparticlename, std::map<
 	}while(BFtimess.good());
 	std::istringstream(conf["spinlog"]) >> spinlog;
 	std::istringstream(conf["spinloginterval"]) >> spinloginterval;
+	std::istringstream(conf["spinlogtimeinterval"]) >> spinlogtimeinterval;
 }
 
 void TBFIntegrator::Binterp(value_type t, value_type B[3]){
@@ -57,9 +58,14 @@ void TBFIntegrator::operator()(const state_type &y, value_type x){
 		BFlogpol = log10(0.5-BFpol);
 	else if (BFpol==0.5)
 		BFlogpol = 0.0;
-	fspinout << x << " " << BFBws << " " << BFpol << " " << BFlogpol << " "
+		
+	if ( x - prevTimeOut >= spinlogtimeinterval ) { // so that the output to the spin log can be reduced
+		fspinout << x << " " << BFBws << " " << BFpol << " " << BFlogpol << " "
 			<< 2*y[0] << " " << 2*y[1] << " " << 2*y[2] << " "
 			<< B[0] << " " << B[1] << " " << B[2] << '\n';
+
+		prevTimeOut = x;
+	}
 }
 long double TBFIntegrator::Integrate(double x1, double y1[6], double dy1dx[6], double B1[4][4], double E1[3],
 					double x2, double y2[6], double dy2dx[6], double B2[4][4], double E2[3]){
@@ -85,7 +91,7 @@ long double TBFIntegrator::Integrate(double x1, double y1[6], double dy1dx[6], d
 				}
 				else
 					I_n[2] = 0.5;
-				starttime = x1;
+				starttime = x1, prevTimeOut = 0;
 				std::cout << "\nBF starttime, " << x1 << " ";
 //					stepper = boost::numeric::odeint::make_dense_output((value_type)1e-12, (value_type)1e-12, stepper_type());
 //					stepper = boost::numeric::odeint::make_controlled(static_cast<value_type>(1e-12), static_cast<value_type>(1e-12), stepper_type());

--- a/bruteforce.cpp
+++ b/bruteforce.cpp
@@ -59,7 +59,7 @@ void TBFIntegrator::operator()(const state_type &y, value_type x){
 		BFlogpol = 0.0;
 	fspinout << x << " " << BFBws << " " << BFpol << " " << BFlogpol << " "
 			<< 2*y[0] << " " << 2*y[1] << " " << 2*y[2] << " "
-			<< B[0]/BFBws << " " << B[1]/BFBws << " " << B[2]/BFBws << '\n';
+			<< B[0] << " " << B[1] << " " << B[2] << '\n';
 }
 
 long double TBFIntegrator::Integrate(double x1, double y1[6], double B1[4][4],

--- a/bruteforce.cpp
+++ b/bruteforce.cpp
@@ -14,7 +14,7 @@ TBFIntegrator::TBFIntegrator(double agamma, std::string aparticlename, std::map<
 	}while(BFtimess.good());
 	std::istringstream(conf["spinlog"]) >> spinlog;
 	std::istringstream(conf["spinloginterval"]) >> spinloginterval;
-	std::istringstream(conf["spinlogtimeinterval"]) >> spinlogtimeinterval;
+	std::istringstream(conf["spinlogtimeoutinterval"]) >> spinlogtimeoutinterval;
 }
 
 void TBFIntegrator::Binterp(value_type t, value_type B[3]){
@@ -59,7 +59,7 @@ void TBFIntegrator::operator()(const state_type &y, value_type x){
 	else if (BFpol==0.5)
 		BFlogpol = 0.0;
 		
-	if ( x - prevTimeOut >= spinlogtimeinterval ) { // so that the output to the spin log can be reduced
+	if ( x - prevTimeOut >= spinlogtimeoutinterval ) { // so that the output to the spin log can be reduced
 		fspinout << x << " " << BFBws << " " << BFpol << " " << BFlogpol << " "
 			<< 2*y[0] << " " << 2*y[1] << " " << 2*y[2] << " "
 			<< B[0] << " " << B[1] << " " << B[2] << '\n';

--- a/bruteforce.h
+++ b/bruteforce.h
@@ -95,15 +95,18 @@ public:
 	 *
 	 * @param x1 Time at first track point.
 	 * @param y1 State vector at first track point.
+	 * @param dy1dx Temporal derivative of state vector at first track point.
 	 * @param B1 Magnetic field at first track point.
+	 * @param E1 Electric field at first track point.
 	 * @param x2 Time at second track point.
 	 * @param y2 State vector at second track point.
+	 * @param dy2dx Temporal derivative of state vector at second track point.
 	 * @param B2 Magnetic field at second track point.
 	 *
 	 * @return Probability, that NO spin flip occured (usually close to 1).
 	 */
-	long double Integrate(double x1, double y1[6], double B1[4][4],
-						double x2, double y2[6], double B2[4][4]);
+	long double Integrate(double x1, double y1[6], double dy1dx[6], double B1[4][4], double E1[3], 
+						double x2, double y2[6], double dy2dx[6], double B2[4][4], double E2[3]);
 
 };
 

--- a/bruteforce.h
+++ b/bruteforce.h
@@ -37,7 +37,7 @@ private:
 	double BFBminmem; ///< Stores minimum field during one spin track for information
 	bool spinlog; ///< Should the tracking be logged to file?
 	double spinloginterval; ///< Time interval between log file entries.
-	double spinlogtimeinterval; ///< Prints to the spin log only after the specified spinlogtimeinterval has passed
+	double spinlogtimeoutinterval; ///< Prints to the spin log only after the specified spinlogtimeoutinterval has passed
 	long int intsteps; ///< Count integrator steps during spin tracking for information.
 	std::ofstream &fspinout; ///< file to log into
 	double starttime; ///< time of last integration start

--- a/bruteforce.h
+++ b/bruteforce.h
@@ -37,10 +37,12 @@ private:
 	double BFBminmem; ///< Stores minimum field during one spin track for information
 	bool spinlog; ///< Should the tracking be logged to file?
 	double spinloginterval; ///< Time interval between log file entries.
+	double spinlogtimeinterval; ///< Prints to the spin log only after the specified spinlogtimeinterval has passed
 	long int intsteps; ///< Count integrator steps during spin tracking for information.
 	std::ofstream &fspinout; ///< file to log into
 	double starttime; ///< time of last integration start
-
+	double prevTimeOut; ///< Time when the previous write to the spinlog occurred
+	
 	value_type t1; ///< field interpolation start time
 	value_type t2; ///< field interpolation end time
 	value_type cx[4]; ///< cubic spline coefficients for magnetic field x-component

--- a/electron.cpp
+++ b/electron.cpp
@@ -13,7 +13,7 @@ ofstream TElectron::snapshotout; ///< snapshot file stream
 ofstream TElectron::trackout; ///< tracklog file stream
 ofstream TElectron::hitout; ///< hitlog file stream
 ofstream TElectron::spinout; ///< spinlog file stream
-
+ofstream TElectron::spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
 
 TElectron::TElectron(int number, double t, double x, double y, double z, double E, double phi, double theta, int polarisation, TMCGenerator &amc, TGeometry &geometry, TFieldManager *afield)
 			: TParticle(NAME_ELECTRON, -ele_e, m_e, 0, 0, number, t, x, y, z, E, phi, theta, polarisation, amc, geometry, afield){

--- a/electron.h
+++ b/electron.h
@@ -43,7 +43,8 @@ protected:
 	static ofstream trackout; ///< tracklog file stream
 	static ofstream hitout; ///< hitlog file stream
 	static ofstream spinout; ///< spinlog file stream
-
+	static ofstream spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
+	
 	/**
 	 * This method is executed, when a particle crosses a material boundary.
 	 *
@@ -152,10 +153,20 @@ protected:
 	/**
 	 * Get spin log stream.
 	 *
-	 * @return Returns static spinout stream to use same stream for all TNeutrons
+	 * @return Returns static spinout stream to use same stream for all TElectrons
 	 */
 	ofstream& GetSpinOut(){
 		return spinout;
+	};
+
+	
+	/**
+	 * Get secondary spin log stream used for spin integration of anti-parallel E-field.
+	 *
+	 * @return Returns static spinout stream to use same stream for all TElectrons
+	 */
+	ofstream& GetSpinOut2(){
+		return spinout2;
 	};
 
 };

--- a/fields.h
+++ b/fields.h
@@ -12,6 +12,7 @@
 #include "field_2d.h"
 #include "field_3d.h"
 #include "conductor.h"
+#include "edmfields.h"
 #include "globals.h"
 
 /**

--- a/in/particle.in
+++ b/in/particle.in
@@ -25,7 +25,7 @@ snapshots 50 100 150 200 250 300 350 400 450 500 550 600 650 700 750 800 850 900
 spinlog 0			# print spin tracking to file
 spinloginterval 5e-7	# min. time interval [s] between track points in spinlog file
 simulEFieldSpinInteg 0  # does spin integration using both parallel and anti-parallel E fields (two spin logs will be produced 0000particleEup.out and 0000particleEdown.out)
-spinlogtimeinterval 0.1   # writes to spin log only after the specified spinlogtimeinterval has passed
+spinlogtimeoutinterval 0.1   # writes to spin log only after the specified spinlogtimeoutinterval has passed
 
 BFtimes	500 700		# do brute force spin tracking between these points in time
 BFmaxB 0.1			# do brute force spin tracking when absolute magnetic field is below this value [T]

--- a/in/particle.in
+++ b/in/particle.in
@@ -18,12 +18,14 @@ theta_v sin(x)		# differential initial distribution of polar angle of velocity -
 
 endlog 1			# print start and end values to file
 tracklog 0			# print track to file
+trackloginterval 5e-3	# min. distance interval [m] between track points in tracklog file
 hitlog 0			# print geometry hits to file
 snapshotlog 1		# print start and end values at these times to file
-spinlog 0			# print spin tracking to file
 snapshots 50 100 150 200 250 300 350 400 450 500 550 600 650 700 750 800 850 900 950 1000 # times from start of simulation to take snapshots
-trackloginterval 5e-3	# min. distance interval [m] between track points in tracklog file
+spinlog 0			# print spin tracking to file
 spinloginterval 5e-7	# min. time interval [s] between track points in spinlog file
+simulEFieldSpinInteg 0  # does spin integration using both parallel and anti-parallel E fields (two spin logs will be produced 0000particleEup.out and 0000particleEdown.out)
+spinlogtimeinterval 0.1   # writes to spin log only after the specified spinlogtimeinterval has passed
 
 BFtimes	500 700		# do brute force spin tracking between these points in time
 BFmaxB 0.1			# do brute force spin tracking when absolute magnetic field is below this value [T]

--- a/mercury.cpp
+++ b/mercury.cpp
@@ -13,7 +13,7 @@ ofstream TMercury::snapshotout; ///< snapshot file stream
 ofstream TMercury::trackout; ///< tracklog file stream
 ofstream TMercury::hitout; ///< hitlog file stream
 ofstream TMercury::spinout; ///< spinlog file stream
-
+ofstream TMercury::spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
 
 TMercury::TMercury(int number, double t, double x, double y, double z, double E, double phi, double theta, int polarisation, TMCGenerator &amc, TGeometry &geometry, TFieldManager *afield)
 			: TParticle(NAME_MERCURY, 0, m_hg, mu_hgSI, gamma_hg, number, t, x, y, z, E, phi, theta, polarisation, amc, geometry, afield){

--- a/mercury.h
+++ b/mercury.h
@@ -43,7 +43,8 @@ protected:
 	static ofstream trackout; ///< tracklog file stream
 	static ofstream hitout; ///< hitlog file stream
 	static ofstream spinout; ///< spinlog file stream
-
+	static ofstream spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
+	
 	/**
 	 * This method is executed, when a particle encounters a material boundary.
 	 * The atom is reflected specularly or diffusely depending on the material type. 
@@ -158,12 +159,21 @@ protected:
 	/**
 	 * Get spin log stream.
 	 *
-	 * @return Returns static spinout stream to use same stream for all TNeutrons
+	 * @return Returns static spinout stream to use same stream for all TMercurys
 	 */
 	ofstream& GetSpinOut(){
 		return spinout;
 	};
-
+	
+	/**
+	 * Get secondary spin log stream used for spin integration of anti-parallel E-field.
+	 *
+	 * @return Returns static spinout stream to use same stream for all TMercurys
+	 */
+	ofstream& GetSpinOut2(){
+		return spinout2;
+	};
+	
 };
 
 #endif // MERCURY_H_

--- a/neutron.cpp
+++ b/neutron.cpp
@@ -23,7 +23,7 @@ ofstream TNeutron::snapshotout; ///< snapshot file stream
 ofstream TNeutron::trackout; ///< tracklog file stream
 ofstream TNeutron::hitout; ///< hitlog file stream
 ofstream TNeutron::spinout; ///< spinlog file stream
-
+ofstream TNeutron::spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration 
 
 TNeutron::TNeutron(int number, double t, double x, double y, double z, double E, double phi, double theta, int polarisation, TMCGenerator &amc, TGeometry &geometry, TFieldManager *afield)
 		: TParticle(NAME_NEUTRON, 0, m_n, mu_nSI, gamma_n, number, t, x, y, z, E, phi, theta, polarisation, amc, geometry, afield){

--- a/neutron.h
+++ b/neutron.h
@@ -59,7 +59,8 @@ protected:
 	static ofstream trackout; ///< tracklog file stream
 	static ofstream hitout; ///< hitlog file stream
 	static ofstream spinout; ///< spinlog file stream
-
+	static ofstream spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
+	
 	/**
 	 * Check for reflection/transmission/absorption on surfaces.
 	 *
@@ -213,7 +214,17 @@ protected:
 	ofstream& GetSpinOut(){
 		return spinout;
 	};
-
+	
+	
+	/**
+	 * Get secondary spin log stream used for spin integration of anti-parallel E-field.
+	 *
+	 * @return Returns static spinout stream to use same stream for all TNeutrons
+	 */
+	ofstream& GetSpinOut2(){
+		return spinout2;
+	};
+	
 private:
 	/**
 	 * Check if the MicroRoughness is model is applicable to the current interaction

--- a/out/merge_all.c
+++ b/out/merge_all.c
@@ -15,7 +15,7 @@ using namespace std;
  * @param filematch Merge files whose names match this regular expression (default: read all)
  * @param path Merge files in this folder (default: current folder)
  */
-void merge_all(const char *filematch = "[0-9]+[a-z]+.out", const char *path = ".")
+void merge_all(const char *filematch = "[0-9]+[A-Za-z]+.out", const char *path = ".")
 {
 	TFile *outfile = new TFile("out.root","RECREATE"); // create ROOT file
 	ifstream infile;

--- a/particle.cpp
+++ b/particle.cpp
@@ -86,8 +86,8 @@ void TParticle::Integrate(double tmax, map<string, string> &conf){
 
 	// set initial values for integrator
 	value_type x = tend, x1, x2;
-	state_type y = yend, dydx;
-	state_type y1(6), y2(6);
+	state_type y = yend; 
+	state_type y1(6), y2(6), dy1dx(6), dy2dx(6); //acceleration is required for finding temporal derivatives of vxE
 	int polarisation = polend;
 	value_type h = 0.001/sqrt(yend[3]*yend[3] + yend[4]*yend[4] + yend[5]*yend[5]); // first guess for stepsize
 
@@ -185,10 +185,19 @@ void TParticle::Integrate(double tmax, map<string, string> &conf){
 			}
 
 			if (field){
-				double B1[4][4], B2[4][4];
+				double B1[4][4], B2[4][4], E1[3], E2[3], v_pot1, v_pot2;
 				field->BField(y1[0], y1[1], y1[2], x1, B1);
 				field->BField(y2[0], y2[1], y2[2], x2, B2);
-				long double noflip = BFint.Integrate(x1, &y1[0], B1, x2, &y2[0], B2);
+				
+				//Need the E field to include the vxE effect in spin tracking
+				field->EField( y1[0], y1[1], y1[2], x1, v_pot1, E1 ); 
+				field->EField( y2[0], y2[1], y2[2], x2, v_pot2, E2 );		
+				
+				//Values of dy1dx and dy2dx are updated because they are passed by reference
+				derivs(x1, y1, dy1dx);
+				derivs(x2, y2, dy2dx);	
+		
+				long double noflip = BFint.Integrate(x1, &y1[0], &dy1dx[0], B1, E1, x2, &y2[0], &dy2dx[0], B2, E2);
 				if (mc->UniformDist(0,1) > noflip)
 					polarisation *= -1;
 				noflipprob *= noflip; // accumulate no-spin-flip probability

--- a/particle.cpp
+++ b/particle.cpp
@@ -121,7 +121,6 @@ void TParticle::Integrate(double tmax, map<string, string> &conf){
 	istringstream(conf["flipspin"]) >> flipspin;
 	
 	TBFIntegrator *BFint, *BFintup, *BFintdown;
-	ofstream edownSpinOut; //needed to create a different ofstream for the E-field antiparallel spin integration
 	
 	if (simulEFieldSpinInteg) {
 		//Different names so that two different spin logs would be produced if so required
@@ -130,7 +129,7 @@ void TParticle::Integrate(double tmax, map<string, string> &conf){
 		//One of the BFintup object will integrate the spin with the E field given 
 		//and the BFintdown object will integrate the spin with the reverse of the E field given
 		BFintup = new TBFIntegrator(gamma, eupName, conf, GetSpinOut()); 
-		BFintdown = new TBFIntegrator(gamma, edownName, conf, edownSpinOut); 
+		BFintdown = new TBFIntegrator(gamma, edownName, conf, GetSpinOut2()); 
 	} else
 		BFint = new TBFIntegrator(gamma, name, conf, GetSpinOut());	
 	

--- a/particle.h
+++ b/particle.h
@@ -343,7 +343,15 @@ protected:
 	 * @return Reference to spin log stream
 	 */
 	virtual ofstream& GetSpinOut() = 0;
-
+	
+	/**
+	 * Get secondary spin log stream used for the output from the simultaneous anti-parallel E field spin integration.
+	 *
+	 * Has to be derived by all derived classes.
+	 *
+	 * @return Reference to spin log stream
+	 */
+	virtual ofstream& GetSpinOut2() = 0;
 
 	/**
 	 * Print start and current values to a stream.

--- a/proton.cpp
+++ b/proton.cpp
@@ -13,7 +13,7 @@ ofstream TProton::snapshotout; ///< snapshot file stream
 ofstream TProton::trackout; ///< tracklog file stream
 ofstream TProton::hitout; ///< hitlog file stream
 ofstream TProton::spinout; ///< spinlog file stream
-
+ofstream TProton::spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
 
 TProton::TProton(int number, double t, double x, double y, double z, double E, double phi, double theta, int polarisation, TMCGenerator &amc, TGeometry &geometry, TFieldManager *afield)
 		: TParticle(NAME_PROTON, ele_e, m_p, 0, 0, number, t, x, y, z, E, phi, theta, polarisation, amc, geometry, afield){

--- a/proton.h
+++ b/proton.h
@@ -44,7 +44,8 @@ protected:
 	static ofstream trackout; ///< tracklog file stream
 	static ofstream hitout; ///< hitlog file stream
 	static ofstream spinout; ///< spinlog file stream
-
+	static ofstream spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
+	
 	/**
 	 * This method is executed, when a particle crosses a material boundary.
 	 *
@@ -153,12 +154,21 @@ protected:
 	/**
 	 * Get spin log stream.
 	 *
-	 * @return Returns static spinout stream to use same stream for all TNeutrons
+	 * @return Returns static spinout stream to use same stream for all TProtons
 	 */
 	ofstream& GetSpinOut(){
 		return spinout;
 	};
-
+	
+	/**
+	 * Get secondary spin log stream used for spin integration of anti-parallel E-field.
+	 *
+	 * @return Returns static spinout stream to use same stream for all TProtons
+	 */
+	ofstream& GetSpinOut2(){
+		return spinout2;
+	};
+	
 };
 
 #endif // PROTON_H_

--- a/xenon.cpp
+++ b/xenon.cpp
@@ -13,7 +13,7 @@ ofstream TXenon::snapshotout; ///< snapshot file stream
 ofstream TXenon::trackout; ///< tracklog file stream
 ofstream TXenon::hitout; ///< hitlog file stream
 ofstream TXenon::spinout; ///< spinlog file stream
-
+ofstream TXenon::spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
 
 TXenon::TXenon(int number, double t, double x, double y, double z, double E, double phi, double theta, int polarisation, TMCGenerator &amc, TGeometry &geometry, TFieldManager *afield)
 			: TParticle(NAME_XENON, 0,  m_xe, mu_xeSI, gamma_xe, number, t, x, y, z, E, phi, theta, polarisation, amc, geometry, afield){

--- a/xenon.h
+++ b/xenon.h
@@ -43,7 +43,8 @@ protected:
 	static ofstream trackout; ///< tracklog file stream
 	static ofstream hitout; ///< hitlog file stream
 	static ofstream spinout; ///< spinlog file stream
-
+	static ofstream spinout2; ///< spinlog file stream for doing simultaneous anti-parallel Efield spin integration
+	
 	/**
 	 * This method is executed, when a particle encounters a material boundary.
 	 * The atom is reflected specularly or diffusely depending on the material type. 
@@ -158,10 +159,19 @@ protected:
 	/**
 	 * Get spin log stream.
 	 *
-	 * @return Returns static spinout stream to use same stream for all TNeutrons
+	 * @return Returns static spinout stream to use same stream for all TXenons
 	 */
 	ofstream& GetSpinOut(){
 		return spinout;
+	};
+	
+	/**
+	 * Get secondary spin log stream used for spin integration of anti-parallel E-field.
+	 *
+	 * @return Returns static spinout stream to use same stream for all TXenons
+	 */
+	ofstream& GetSpinOut2(){
+		return spinout2;
 	};
 
 };


### PR DESCRIPTION
I added the vxE effect to the BFintegrator and the option of doing simultaneous integration of the particle spin using the anti-parallel version of the current electric field, this is done using two different BFIntegrator objects in particle.cpp. The new "simulEFieldSpinInteg" option in in/particle.in is used to decide if simultaneous integration should take place.

When simultaneous integration is chosen by the user, two different spin logs are produced in the format 0\*\<jobnum\>\<particle\>Eupspin.out and 0\*\<jobNum\>\<particle\>Edownspin.out, since these contained capital E, the merge_all.c script was modified to also use files that had capital letters.

I also rearranged the options in in/particle.in so that they would be grouped by the input file so snapshots is right after the snapshotlog rather than having all the options to turn on the logs together. Another option called "spinlogtimoutinterval" was added to reduce the amount of output in the spinlog. 

Two things that you should look into in particular: 
1) "spinlogtimeoutinterval" is not the same as "spinloginterval" correct? Could you actually explain what spinloginterval actually does because when I set it to a very high value like 5E-2 rather than 5E-7, the output is not every 5E-2 seconds but something much smaller (is it the steps of the integrator)? Each row is also repeated twice when the spinloginterval is set to 5E-2. 

2) I had to declare new ofstream in TParticle::Integrate so that the output of anti-parallel E-field integration would take place in a different place. Is this appropriate or is there a better way to handle this case? 


